### PR TITLE
fix: clean client pages metadata

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -1,9 +1,6 @@
 /** @type {import('next').NextConfig} */
 const nextConfig = {
-  reactStrictMode: true,
-  experimental: {
-    appDir: true
-  }
+  reactStrictMode: true
 };
 
 module.exports = nextConfig;

--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
   },
   "devDependencies": {
     "eslint": "^8.57.0",
-    "eslint-config-next": "^14.0.0"
+    "eslint-config-next": "^14.0.0",
+    "@tailwindcss/postcss": "^4.0.0"
   }
 }

--- a/postcss.config.js
+++ b/postcss.config.js
@@ -1,6 +1,6 @@
 module.exports = {
   plugins: {
-    tailwindcss: {},
+    '@tailwindcss/postcss': {},
     autoprefixer: {}
   }
 };

--- a/src/app/admin/page.js
+++ b/src/app/admin/page.js
@@ -3,8 +3,6 @@ import { useEffect, useState } from 'react';
 import ProductCard from '@/components/ProductCard';
 import { Button } from '@/components/ui/button';
 
-export const metadata = { title: 'Admin' };
-
 export default function Admin() {
   const [products, setProducts] = useState([]);
   const [form, setForm] = useState({ id: '', name: '', description: '', price: '', image: '', link: '' });

--- a/src/app/login/page.js
+++ b/src/app/login/page.js
@@ -2,8 +2,6 @@
 import { useState } from 'react';
 import { Button } from '@/components/ui/button';
 
-export const metadata = { title: 'Login' };
-
 export default function Login() {
   const [email, setEmail] = useState('');
   const [password, setPassword] = useState('');

--- a/src/app/products/page.js
+++ b/src/app/products/page.js
@@ -2,8 +2,6 @@
 import { useEffect, useState } from 'react';
 import ProductCard from '@/components/ProductCard';
 
-export const metadata = { title: 'Products' };
-
 export default function Products() {
   const [products, setProducts] = useState([]);
 


### PR DESCRIPTION
## Summary
- remove metadata exports from client-side pages
- simplify Next.js configuration
- prepare Tailwind CSS PostCSS setup

## Testing
- `npm test`
- `npm run lint`
- `npm run build` *(fails: Cannot find module '@tailwindcss/postcss')*

------
https://chatgpt.com/codex/tasks/task_e_68960f89bc4883318ecd3fbbfad755d1